### PR TITLE
Bump CUDA SM support to 120

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,15 @@ CUDA_ARCH = --generate-code arch=compute_30,code=sm_30 \
             --generate-code arch=compute_62,code=sm_62 \
             --generate-code arch=compute_70,code=sm_70 \
             --generate-code arch=compute_72,code=sm_72 \
-            --generate-code arch=compute_75,code=sm_75
+            --generate-code arch=compute_75,code=sm_75 \
+            --generate-code arch=compute_80,code=sm_80 \
+            --generate-code arch=compute_87,code=sm_87 \
+            --generate-code arch=compute_89,code=sm_89 \
+            --generate-code arch=compute_90,code=sm_90 \
+            --generate-code arch=compute_90a,code=sm_90a \
+            --gencode=arch=compute_100,code=sm_100 \
+         			--gencode=arch=compute_120,code=sm_120 \
+         			--gencode=arch=compute_120,code=compute_120
 
 # What libraries to link and how
 ifeq ($(LINKING), STATIC)

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,10 @@ GIT_HASH       = -D__KWAVE_GIT_HASH__=\"468dc31c2842a7df5f2a07c3a13c16c9b0b2b770
 # Replace tabs by spaces
 .RECIPEPREFIX += 
 
-# What CUDA GPU architectures to include in the binary
+# What CUDA GPU architectures to include in the binary.
+# Note: this Makefile is the legacy build path; the unified-CI build
+# uses the .vcxproj directly via MSBuild. Keep the two arch lists in
+# sync if you change one.
 CUDA_ARCH = --generate-code arch=compute_30,code=sm_30 \
             --generate-code arch=compute_32,code=sm_32 \
             --generate-code arch=compute_35,code=sm_35 \
@@ -124,13 +127,14 @@ CUDA_ARCH = --generate-code arch=compute_30,code=sm_30 \
             --generate-code arch=compute_72,code=sm_72 \
             --generate-code arch=compute_75,code=sm_75 \
             --generate-code arch=compute_80,code=sm_80 \
+            --generate-code arch=compute_86,code=sm_86 \
             --generate-code arch=compute_87,code=sm_87 \
             --generate-code arch=compute_89,code=sm_89 \
             --generate-code arch=compute_90,code=sm_90 \
             --generate-code arch=compute_90a,code=sm_90a \
-            --gencode=arch=compute_100,code=sm_100 \
-         			--gencode=arch=compute_120,code=sm_120 \
-         			--gencode=arch=compute_120,code=compute_120
+            --generate-code arch=compute_100,code=sm_100 \
+            --generate-code arch=compute_120,code=sm_120 \
+            --generate-code arch=compute_120,code=compute_120
 
 # What libraries to link and how
 ifeq ($(LINKING), STATIC)

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 10.2.props" />
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -183,13 +183,13 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <GenerateRelocatableDeviceCode>true</GenerateRelocatableDeviceCode>
-      <CodeGeneration>compute_30,sm_30;compute_32,sm_32;compute_35,sm_35;compute_37,sm_37;compute_50,sm_50;compute_52,sm_52;compute_60,sm_60;compute_61,sm_61;compute_70,sm_70;compute_75,sm_75;</CodeGeneration>
+      <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_86,sm_86;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;compute_100,sm_100;compute_120,sm_120;compute_120,compute_120;</CodeGeneration>
       <FastMath>true</FastMath>
       <MaxRegCount />
     </CudaCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 10.2.targets" />
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets" />
   </ImportGroup>
 </Project>


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends CUDA SM support to Blackwell (sm_120) by updating both the Makefile and the Visual Studio project file, and bumps the CUDA toolkit reference in the `.vcxproj` from 10.2 to 13.0.

- **`.vcxproj`**: CUDA build customizations updated to 13.0; `CodeGeneration` trimmed to sm_75\u2013sm_120, correctly dropping Kepler/Maxwell/Pascal/Volta targets that CUDA 13.0 no longer supports for offline compilation.
- **`Makefile`**: sm_80\u2013sm_120 appended to `CUDA_ARCH`, but pre-Ampere targets (sm_30\u2013sm_72) remain, even though CUDA 13.0 removed offline compilation support for Maxwell, Pascal, and Volta \u2014 and Kepler was already gone before CUDA 12. A comment was added noting the two lists should stay in sync, but they now diverge in the opposite direction from what was intended.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the Windows/MSBuild path; the Makefile build will fail with any CUDA 13.0 toolchain due to retained deprecated targets.

The `.vcxproj` changes are clean and correct. The Makefile still targets sm_30–sm_72, all of which lost offline compilation support in CUDA 13.0 — the same toolkit version required to compile sm_120. Building from the Makefile on a machine with CUDA 13.0 will produce hard errors for those deprecated targets.

Makefile — the CUDA_ARCH list needs the same pre-Ampere trim applied in the .vcxproj.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Makefile | Adds sm_80–sm_120 to CUDA_ARCH but retains Kepler/Maxwell/Pascal/Volta targets (sm_30–sm_72) that CUDA 13.0 removed, making Makefile builds fail with any toolchain new enough to compile sm_120. |
| kspaceFirstOrder-CUDA.vcxproj | Updates CUDA toolkit from 10.2 to 13.0 and trims CodeGeneration to sm_75–sm_120; correctly drops all CUDA-13.0-unsupported targets (Kepler through Volta, below sm_75). |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build Request] --> B{Build Path}
    B -->|MSBuild / CI| C[kspaceFirstOrder-CUDA.vcxproj]
    B -->|Legacy / Linux| D[Makefile]

    C --> E[CUDA 13.0 props+targets]
    E --> F[sm_75 to sm_120 / compute_120 PTX]
    F --> G[Build succeeds]

    D --> H[System nvcc]
    H --> I{CUDA version?}
    I -->|less than 12.0| J[sm_30 to sm_120 / All targets compiled]
    I -->|13.0 or newer| K[sm_30 to sm_72 removed from toolkit]
    K --> L[Compilation error for deprecated targets]
    J --> M[Build succeeds but sm_120 unsupported]
```

<sub>Reviews (2): Last reviewed commit: ["Address Greptile P2s + fix vcxproj CUDA ..."](https://github.com/waltsims/kspacefirstorder-cuda-windows/commit/34480ea7fbe76aef119d155a84025382904e840d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32456409)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->