### PR TITLE
Cuda 12 support

### DIFF
--- a/Hdf5/Hdf5File.h
+++ b/Hdf5/Hdf5File.h
@@ -464,6 +464,7 @@
 #include <hdf5.h>
 #include <hdf5_hl.h>
 #include <map>
+#include <string>
 
 #include <Utils/DimensionSizes.h>
 

--- a/Hdf5/Hdf5FileHeader.h
+++ b/Hdf5/Hdf5FileHeader.h
@@ -74,6 +74,7 @@
 #define HDF5_FILE_HEADER_H
 
 #include <map>
+#include <string>
 
 #include <Hdf5/Hdf5File.h>
 #include <Utils/DimensionSizes.h>

--- a/MatrixClasses/CufftComplexMatrix.cpp
+++ b/MatrixClasses/CufftComplexMatrix.cpp
@@ -59,22 +59,19 @@ cufftHandle CufftComplexMatrix::sC2RFftPlan1DZ = cufftHandle();
  */
 std::map<cufftResult, ErrorMessage> CufftComplexMatrix::sCufftErrorMessages
 {
-  {CUFFT_INVALID_PLAN             , kErrFmtCufftInvalidPlan},
-  {CUFFT_ALLOC_FAILED             , kErrFmtCufftAllocFailed},
-  {CUFFT_INVALID_TYPE             , kErrFmtCufftInvalidType},
-  {CUFFT_INVALID_VALUE            , kErrFmtCufftInvalidValue},
-  {CUFFT_INTERNAL_ERROR           , kErrFmtCuFFTInternalError},
-  {CUFFT_EXEC_FAILED              , kErrFmtCufftExecFailed},
-  {CUFFT_SETUP_FAILED             , kErrFmtCufftSetupFailed},
-  {CUFFT_INVALID_SIZE             , kErrFmtCufftInvalidSize},
-  {CUFFT_UNALIGNED_DATA           , kErrFmtCufftUnalignedData},
-  {CUFFT_INCOMPLETE_PARAMETER_LIST, kErrFmtCufftIncompleteParaterList},
-  {CUFFT_INVALID_DEVICE           , kErrFmtCufftInvalidDevice},
-  {CUFFT_PARSE_ERROR              , kErrFmtCufftParseError},
-  {CUFFT_NO_WORKSPACE             , kErrFmtCufftNoWorkspace},
-  {CUFFT_NOT_IMPLEMENTED          , kErrFmtCufftNotImplemented},
-  {CUFFT_LICENSE_ERROR            , kErrFmtCufftLicenseError},
-  {CUFFT_NOT_SUPPORTED            , kErrFmtCufftNotSupported}
+  {CUFFT_INVALID_PLAN   , kErrFmtCufftInvalidPlan},
+  {CUFFT_ALLOC_FAILED   , kErrFmtCufftAllocFailed},
+  {CUFFT_INVALID_TYPE   , kErrFmtCufftInvalidType},
+  {CUFFT_INVALID_VALUE  , kErrFmtCufftInvalidValue},
+  {CUFFT_INTERNAL_ERROR , kErrFmtCuFFTInternalError},
+  {CUFFT_EXEC_FAILED    , kErrFmtCufftExecFailed},
+  {CUFFT_SETUP_FAILED   , kErrFmtCufftSetupFailed},
+  {CUFFT_INVALID_SIZE   , kErrFmtCufftInvalidSize},
+  {CUFFT_UNALIGNED_DATA , kErrFmtCufftUnalignedData},
+  {CUFFT_INVALID_DEVICE , kErrFmtCufftInvalidDevice},
+  {CUFFT_NO_WORKSPACE   , kErrFmtCufftNoWorkspace},
+  {CUFFT_NOT_IMPLEMENTED, kErrFmtCufftNotImplemented},
+  {CUFFT_NOT_SUPPORTED  , kErrFmtCufftNotSupported}
 };
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/MatrixClasses/CufftComplexMatrix.cpp
+++ b/MatrixClasses/CufftComplexMatrix.cpp
@@ -71,7 +71,17 @@ std::map<cufftResult, ErrorMessage> CufftComplexMatrix::sCufftErrorMessages
   {CUFFT_INVALID_DEVICE , kErrFmtCufftInvalidDevice},
   {CUFFT_NO_WORKSPACE   , kErrFmtCufftNoWorkspace},
   {CUFFT_NOT_IMPLEMENTED, kErrFmtCufftNotImplemented},
-  {CUFFT_NOT_SUPPORTED  , kErrFmtCufftNotSupported}
+  {CUFFT_NOT_SUPPORTED  , kErrFmtCufftNotSupported},
+  // Codes deprecated in cuFFT 12.9 and removed in 13.0; preserved here
+  // when building against older toolchains so cuFFT 12.x users still
+  // get descriptive error messages instead of the generic "unknown
+  // error" fallback. CUDART_VERSION is exposed by <cuda_runtime_api.h>
+  // via the cufft.h include above.
+#if CUDART_VERSION < 13000
+  {CUFFT_INCOMPLETE_PARAMETER_LIST, kErrFmtCufftIncompleteParaterList},
+  {CUFFT_PARSE_ERROR              , kErrFmtCufftParseError},
+  {CUFFT_LICENSE_ERROR            , kErrFmtCufftLicenseError},
+#endif
 };
 //----------------------------------------------------------------------------------------------------------------------
 

--- a/Readme.md
+++ b/Readme.md
@@ -5,7 +5,7 @@ of propagating acoustic waves in 1D, 2D, or 3D. The toolbox has a wide range of
 functionality, but at its heart is an advanced numerical model that can account
 for both linear or nonlinear wave propagation, an arbitrary distribution of
 heterogeneous material parameters, and power law acoustic absorption.
-See k-Wave website(http://www.k-wave.org).
+See the k-Wave website (http://www.k-wave.org).
 
 This project is a part of the k-Wave toolbox accelerating 2D/3D simulations
 using an optimized CUDA/C++ implementation to run small to moderate grid sizes

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -84,9 +84,6 @@
     <RootNamespace>k_wave_fluid_cuda</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
-  <PropertyGroup>
-    <VCToolsVersion Condition="'$(VCToolsVersion)' == ''">14.36.32532</VCToolsVersion>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -105,6 +102,14 @@
     </UseOfMfc>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <PreferredCudaVCToolsVersion>14.38.33130</PreferredCudaVCToolsVersion>
+    <FallbackCudaVCToolsVersion>14.29.30133</FallbackCudaVCToolsVersion>
+  </PropertyGroup>
+  <PropertyGroup>
+    <VCToolsVersion Condition="'$(VCToolsVersion)' == '' and Exists('$(VCInstallDir)Tools\\MSVC\\$(PreferredCudaVCToolsVersion)\\bin\\Hostx64\\x64\\cl.exe')">$(PreferredCudaVCToolsVersion)</VCToolsVersion>
+    <VCToolsVersion Condition="'$(VCToolsVersion)' == '' and Exists('$(VCInstallDir)Tools\\MSVC\\$(FallbackCudaVCToolsVersion)\\bin\\Hostx64\\x64\\cl.exe')">$(FallbackCudaVCToolsVersion)</VCToolsVersion>
+  </PropertyGroup>
   <ImportGroup Label="ExtensionSettings">
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" Condition="exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props')" />
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props" Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props') and exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props')" />

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -110,6 +110,9 @@
     <VCToolsVersion Condition="'$(VCToolsVersion)' == '' and Exists('$(VCInstallDir)Tools\\MSVC\\$(PreferredCudaVCToolsVersion)\\bin\\Hostx64\\x64\\cl.exe')">$(PreferredCudaVCToolsVersion)</VCToolsVersion>
     <VCToolsVersion Condition="'$(VCToolsVersion)' == '' and Exists('$(VCInstallDir)Tools\\MSVC\\$(FallbackCudaVCToolsVersion)\\bin\\Hostx64\\x64\\cl.exe')">$(FallbackCudaVCToolsVersion)</VCToolsVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <CudaNvccAllowUnsupportedCompiler Condition="'$(VCToolsVersion)' != '' and $([System.Version]::Parse('$(VCToolsVersion)')).CompareTo($([System.Version]::Parse('14.39.0.0'))) &gt; 0">-allow-unsupported-compiler</CudaNvccAllowUnsupportedCompiler>
+  </PropertyGroup>
   <ImportGroup Label="ExtensionSettings">
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" Condition="exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props')" />
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props" Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props') and exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props')" />
@@ -162,6 +165,7 @@
       <PtxAsOptionV>true</PtxAsOptionV>
       <FastMath>true</FastMath>
       <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
+      <AdditionalCompilerOptions>%(AdditionalCompilerOptions) $(CudaNvccAllowUnsupportedCompiler)</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -192,6 +196,7 @@
       <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
       <FastMath>true</FastMath>
       <MaxRegCount />
+      <AdditionalCompilerOptions>%(AdditionalCompilerOptions) $(CudaNvccAllowUnsupportedCompiler)</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -103,7 +103,8 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-  <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" />
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" Condition="exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props')" />
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props" Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props') and exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props')" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -189,6 +190,7 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets" />
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets" Condition="exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets')" />
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.targets" Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets') and exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.targets')" />
   </ImportGroup>
 </Project>

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 10.2.props" />
+  <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
@@ -190,6 +190,6 @@
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 10.2.targets" />
+    <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets" />
   </ImportGroup>
 </Project>

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -154,8 +154,7 @@
       <PtxAsOptionV>true</PtxAsOptionV>
       <FastMath>true</FastMath>
       <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
-      <AdditionalCompilerOptions>
-      </AdditionalCompilerOptions>
+      <AdditionalCompilerOptions>%(AdditionalCompilerOptions) -allow-unsupported-compiler</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -186,6 +185,7 @@
       <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
       <FastMath>true</FastMath>
       <MaxRegCount />
+      <AdditionalCompilerOptions>%(AdditionalCompilerOptions) -allow-unsupported-compiler</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -111,8 +111,16 @@
     <VCToolsVersion Condition="'$(VCToolsVersion)' == '' and Exists('$(VCInstallDir)Tools\\MSVC\\$(FallbackCudaVCToolsVersion)\\bin\\Hostx64\\x64\\cl.exe')">$(FallbackCudaVCToolsVersion)</VCToolsVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <CudaNvccAllowUnsupportedCompiler Condition="'$(VCToolsVersion)' != '' and $([System.Version]::Parse('$(VCToolsVersion)')).CompareTo($([System.Version]::Parse('14.39.0.0'))) &gt; 0">-allow-unsupported-compiler</CudaNvccAllowUnsupportedCompiler>
+    <CudaNvccAllowUnsupportedCompiler>
+    </CudaNvccAllowUnsupportedCompiler>
   </PropertyGroup>
+  <Choose>
+    <When Condition="'$(VCToolsVersion)' != '' and $([MSBuild]::VersionGreaterThan('$(VCToolsVersion)', '14.39.0'))">
+      <PropertyGroup>
+        <CudaNvccAllowUnsupportedCompiler>-allow-unsupported-compiler</CudaNvccAllowUnsupportedCompiler>
+      </PropertyGroup>
+    </When>
+  </Choose>
   <ImportGroup Label="ExtensionSettings">
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" Condition="exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props')" />
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props" Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props') and exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props')" />
@@ -203,5 +211,5 @@
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets" Condition="exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets')" />
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.targets" Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.targets') and exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.targets')" />
-  </ImportGroup>
+</ImportGroup>
 </Project>

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -125,6 +125,12 @@
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props" Condition="exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props')" />
     <Import Project="$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props" Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props') and exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props')" />
   </ImportGroup>
+  <!-- Fail loudly if neither CUDA version's MSBuild customizations are present.
+       Without this, both Imports above would silently skip, then later CudaCompile
+       items would fail with confusing "MSB4019: customization not found" errors. -->
+  <Target Name="VerifyCudaCustomizations" BeforeTargets="PrepareForBuild">
+    <Error Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props') and !exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props')"
+           Text="Neither CUDA 13.0 nor CUDA 12.2 MSBuild customizations were found under '$(VCTargetsPath)\BuildCustomizations'. Install the CUDA Toolkit (12.2 or 13.0) and ensure 'Visual Studio Integration' is selected in the installer (or copy CUDA*.props/.targets from %CUDA_PATH%\extras\visual_studio_integration\MSBuildExtensions to that path manually)." />
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
@@ -132,15 +138,33 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <!-- Resolve a vcpkg install dir from multiple sources, in order of preference:
+         1. $(VcpkgRoot)       - injected by `vcpkg integrate install` (the
+                                  recommended way; works on dev boxes that ran
+                                  the one-time integrate step)
+         2. $(VCPKG_ROOT)      - environment variable convention used by many
+                                  CI scripts (set by lukka/run-vcpkg, etc.)
+         3. $(VCPKG_INSTALLATION_ROOT) - the variable GitHub-hosted runners
+                                  expose by default for the preinstalled vcpkg
+       Resolved once here so the per-configuration paths below stay readable. -->
+  <PropertyGroup>
+    <ResolvedVcpkgRoot Condition="'$(ResolvedVcpkgRoot)' == '' and '$(VcpkgRoot)' != ''">$(VcpkgRoot)</ResolvedVcpkgRoot>
+    <ResolvedVcpkgRoot Condition="'$(ResolvedVcpkgRoot)' == '' and '$(VCPKG_ROOT)' != ''">$(VCPKG_ROOT)</ResolvedVcpkgRoot>
+    <ResolvedVcpkgRoot Condition="'$(ResolvedVcpkgRoot)' == '' and '$(VCPKG_INSTALLATION_ROOT)' != ''">$(VCPKG_INSTALLATION_ROOT)</ResolvedVcpkgRoot>
+  </PropertyGroup>
+  <Target Name="VerifyVcpkgRoot" BeforeTargets="PrepareForBuild">
+    <Error Condition="'$(ResolvedVcpkgRoot)' == ''"
+           Text="Could not locate vcpkg. Run `vcpkg integrate install` (preferred), set the VCPKG_ROOT environment variable, or rely on the GitHub-hosted-runner VCPKG_INSTALLATION_ROOT. None of those were available." />
+  </Target>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>
     </LinkIncremental>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(VCPKG_ROOT)\installed\x64-windows\include;.;..\Sources</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(VCPKG_ROOT)\installed\x64-windows\lib</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ResolvedVcpkgRoot)\installed\x64-windows\include;.;..\Sources</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(ResolvedVcpkgRoot)\installed\x64-windows\lib</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(VCPKG_ROOT)\installed\x64-windows\include;.;..\Sources</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(VCPKG_ROOT)\installed\x64-windows\lib</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(ResolvedVcpkgRoot)\installed\x64-windows\include;.;..\Sources</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(ResolvedVcpkgRoot)\installed\x64-windows\lib</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -82,14 +82,14 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B040477E-5790-4F5D-B010-B7B57EE26FED}</ProjectGuid>
     <RootNamespace>k_wave_fluid_cuda</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -97,7 +97,7 @@
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>
     </UseOfMfc>
   </PropertyGroup>
@@ -115,12 +115,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>
     </LinkIncremental>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);c:\Program Files\HDF_Group\HDF5\1.10.6\include;.;..\Sources</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;c:\Program Files\HDF_Group\HDF5\1.10.6\lib</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(VCPKG_ROOT)\installed\x64-windows\include;.;..\Sources</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(VCPKG_ROOT)\installed\x64-windows\lib</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);c:\Program Files\HDF_Group\HDF5\1.10.6\include;.;..\Sources</IncludePath>
-    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;c:\Program Files\HDF_Group\HDF5\1.10.6\lib</LibraryPath>
+    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);$(VCPKG_ROOT)\installed\x64-windows\include;.;..\Sources</IncludePath>
+    <LibraryPath>$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64;$(VCPKG_ROOT)\installed\x64-windows\lib</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -152,8 +152,7 @@
       <GenerateRelocatableDeviceCode>true</GenerateRelocatableDeviceCode>
       <PtxAsOptionV>true</PtxAsOptionV>
       <FastMath>true</FastMath>
-      <CodeGeneration>
-      </CodeGeneration>
+      <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
       <AdditionalCompilerOptions>
       </AdditionalCompilerOptions>
     </CudaCompile>
@@ -183,7 +182,7 @@
     <CudaCompile>
       <TargetMachinePlatform>64</TargetMachinePlatform>
       <GenerateRelocatableDeviceCode>true</GenerateRelocatableDeviceCode>
-      <CodeGeneration>compute_30,sm_30;compute_32,sm_32;compute_35,sm_35;compute_37,sm_37;compute_50,sm_50;compute_52,sm_52;compute_60,sm_60;compute_61,sm_61;compute_70,sm_70;compute_75,sm_75;</CodeGeneration>
+      <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
       <FastMath>true</FastMath>
       <MaxRegCount />
     </CudaCompile>

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -131,6 +131,7 @@
   <Target Name="VerifyCudaCustomizations" BeforeTargets="PrepareForBuild">
     <Error Condition="!exists('$(VCTargetsPath)\BuildCustomizations\CUDA 13.0.props') and !exists('$(VCTargetsPath)\BuildCustomizations\CUDA 12.2.props')"
            Text="Neither CUDA 13.0 nor CUDA 12.2 MSBuild customizations were found under '$(VCTargetsPath)\BuildCustomizations'. Install the CUDA Toolkit (12.2 or 13.0) and ensure 'Visual Studio Integration' is selected in the installer (or copy CUDA*.props/.targets from %CUDA_PATH%\extras\visual_studio_integration\MSBuildExtensions to that path manually)." />
+  </Target>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -84,6 +84,9 @@
     <RootNamespace>k_wave_fluid_cuda</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <VCToolsVersion Condition="'$(VCToolsVersion)' == ''">14.36.32532</VCToolsVersion>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -154,7 +157,6 @@
       <PtxAsOptionV>true</PtxAsOptionV>
       <FastMath>true</FastMath>
       <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
-      <AdditionalCompilerOptions>%(AdditionalCompilerOptions) -allow-unsupported-compiler</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -185,7 +187,6 @@
       <CodeGeneration>compute_75,sm_75;compute_80,sm_80;compute_87,sm_87;compute_89,sm_89;compute_90,sm_90;compute_90a,sm_90a;</CodeGeneration>
       <FastMath>true</FastMath>
       <MaxRegCount />
-      <AdditionalCompilerOptions>%(AdditionalCompilerOptions) -allow-unsupported-compiler</AdditionalCompilerOptions>
     </CudaCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/kspaceFirstOrder-CUDA.vcxproj
+++ b/kspaceFirstOrder-CUDA.vcxproj
@@ -144,7 +144,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libszip.lib;libzlib.lib;libhdf5.lib;libhdf5_hl.lib;cufft.lib</AdditionalDependencies>
+      <AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);aec.lib;zlib.lib;hdf5.lib;hdf5_hl.lib;cufft.lib</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);$(CudaToolkitLibDir);</AdditionalLibraryDirectories>
     </Link>
     <CudaCompile>
@@ -176,7 +176,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <SubSystem>Console</SubSystem>
-      <AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);libszip.lib;libzlib.lib;libhdf5.lib;libhdf5_hl.lib;cufft.lib</AdditionalDependencies>
+      <AdditionalDependencies>cudart_static.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);aec.lib;zlib.lib;hdf5.lib;hdf5_hl.lib;cufft.lib</AdditionalDependencies>
       <Version>1.3</Version>
     </Link>
     <CudaCompile>


### PR DESCRIPTION
@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated Windows toolchain and CUDA support with fallbacks to improve build compatibility and broaden supported GPU targets; migrated native dependencies to VCPKG-managed libraries.

- Refactor
  - Standardized dataset name type across headers for consistency.
  - Removed obsolete CUFFT error entries and cleaned up error mappings.

- Style
  - Minor formatting and newline adjustments.

- Documentation
  - Clarified README wording and expanded repository structure notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Visual Studio project to support CUDA 12.2 alongside 13.0, migrates native dependencies (HDF5, zlib, szip) from hard-coded paths to VCPKG, upgrades the platform toolset from `v141` to `v143`, and adds explicit `#include <string>` to two headers.

- **CUDA dual-version fallback**: `CUDA 13.0.props/targets` is imported when present; `CUDA 12.2.props/targets` is used as a fallback. A `VerifyCudaCustomizations` target emits a clear error if neither is found.
- **VCPKG integration**: Hard-coded `C:\Program Files\HDF_Group\...` paths are replaced with `$(ResolvedVcpkgRoot)\installed\x64-windows\...`, resolved from `VcpkgRoot`, `VCPKG_ROOT`, or `VCPKG_INSTALLATION_ROOT`; a `VerifyVcpkgRoot` target guards against a missing root.
- **GPU target expansion**: Release now targets sm_75 through sm_120; Debug gains explicit targets for the same range but is missing `sm_86`, and the Release list contains a redundant `compute_120,compute_120` PTX-only entry after the identical `compute_120,sm_120` entry.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the structural concerns from the previous review round have all been addressed in this revision.

The changes are build-system and header hygiene. The VCPKG path resolution, CUDA version fallback, and diagnostic targets all look correct. The two remaining observations (missing sm_86 in Debug and a redundant compute_120 PTX entry in Release) are non-blocking and do not affect correctness.

kspaceFirstOrder-CUDA.vcxproj — the Debug CodeGeneration list and the trailing Release entry are worth a quick look before merging.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| kspaceFirstOrder-CUDA.vcxproj | Major overhaul: toolset upgraded to v143, CUDA dual-version fallback (13.0 → 12.2) added with diagnostic errors, VCPKG replaces hard-coded HDF5 paths, GPU targets expanded; sm_86 is present in Release but missing from the Debug CodeGeneration list |
| MatrixClasses/CufftComplexMatrix.cpp | Removed three CUFFT error codes (INCOMPLETE_PARAMETER_LIST, PARSE_ERROR, LICENSE_ERROR) from the error map and reformatted the table; the removed codes remain defined in CUDA 12.2 headers, so they will silently fall back to the generic error message on that toolchain |
| Hdf5/Hdf5File.h | Added explicit `#include <string>` to satisfy the `MatrixName = std::string` alias without relying on transitive inclusion |
| Hdf5/Hdf5FileHeader.h | Added explicit `#include <string>` for the same reason as Hdf5File.h |
| Readme.md | Minor grammar fix; compilation instructions still reference the old CUDA/VS/HDF5 toolchain and do not mention VCPKG_ROOT requirement |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Readme.md`, line 41-72 ([link](https://github.com/waltsims/kspacefirstorder-cuda-windows/blob/319fec643a99cc0bdc9743574211b1cadd52c5eb/Readme.md#L41-L72)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **README compilation instructions are out of date**

   The Compilation section still refers to CUDA 9.0–10.2, Visual Studio 2017 (`v141` toolset), and a manual HDF5 1.10.x installation to a hard-coded path. This PR updates the project to CUDA 12.2/13.0, the `v143` (VS 2022) toolset, and VCPKG-managed HDF5/zlib/libaec. Users following the README will install the wrong prerequisites and hit confusing failures. The `VCPKG_ROOT` environment variable requirement is also unmentioned, which will cause silent include/library path failures for anyone who hasn't set it.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["Restore cuFFT 12.x error codes via #if C..."](https://github.com/waltsims/kspacefirstorder-cuda-windows/commit/4b90ae9a71c82cfe24ab35338ab02a8199540957) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32456393)</sub>

<!-- /greptile_comment -->