### PR TITLE
Add CMakeLists.txt + Blackwell-aware SetupCUDA.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,204 @@
+cmake_minimum_required(VERSION 3.24)
+
+if(POLICY CMP0104)
+  cmake_policy(SET CMP0104 NEW) # CUDA architecture handling
+endif()
+if(POLICY CMP0146)
+  cmake_policy(SET CMP0146 NEW) # CUDA Clang host compilation
+endif()
+
+project(kspaceFirstOrderCUDA LANGUAGES CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# -------------------------------------------------------------------------------------------------
+# Options mirroring the legacy Makefile and Visual Studio switches
+# -------------------------------------------------------------------------------------------------
+set(KSPACE_CPU_ARCH "native" CACHE STRING "Target CPU ISA tuning (native, avx, avx2, avx512).")
+set_property(CACHE KSPACE_CPU_ARCH PROPERTY STRINGS native avx avx2 avx512)
+
+option(KSPACE_ENABLE_OPENMP "Enable OpenMP parallelism in host code." ON)
+option(KSPACE_ENABLE_FAST_MATH "Enable aggressive fast-math flags on the host compiler." ON)
+
+set(KSPACE_CUDA_ARCH_LIST "" CACHE STRING "Override CUDA architectures (semicolon, space, or comma separated).")
+
+if(KSPACE_CUDA_ARCH_LIST)
+  set(CMAKE_CUDA_ARCHITECTURES "${KSPACE_CUDA_ARCH_LIST}")
+elseif(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  # Default to modern architectures supported by current CUDA toolkits.
+  # sm_100/sm_120 (Blackwell) require CUDA 12.8+; SetupCUDA.cmake drops
+  # them automatically when an older toolchain is detected.
+  # Override via KSPACE_CUDA_ARCH_LIST if needed.
+  set(CMAKE_CUDA_ARCHITECTURES "75;80;86;87;89;90;90a;100;120")
+endif()
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/SetupCUDA.cmake)
+
+set(CMAKE_CUDA_STANDARD 11)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_EXTENSIONS OFF)
+
+if(MSVC AND KSPACE_ENABLE_OPENMP)
+  message(WARNING "Disabling OpenMP: MSVC requires signed loop indices and /openmp:experimental, which the current codebase does not satisfy.")
+  set(KSPACE_ENABLE_OPENMP OFF CACHE BOOL "Enable OpenMP parallelism in host code." FORCE)
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Dependencies
+# -------------------------------------------------------------------------------------------------
+find_package(CUDAToolkit REQUIRED)
+find_package(HDF5 REQUIRED COMPONENTS C HL)
+find_package(ZLIB REQUIRED)
+find_package(SZIP QUIET)
+
+if(KSPACE_ENABLE_OPENMP)
+  find_package(OpenMP)
+  if(NOT OpenMP_CXX_FOUND)
+    message(WARNING "OpenMP requested but not found; disabling.")
+    set(KSPACE_ENABLE_OPENMP OFF CACHE BOOL "Enable OpenMP parallelism in host code." FORCE)
+  endif()
+endif()
+
+# -------------------------------------------------------------------------------------------------
+# Source lists
+# -------------------------------------------------------------------------------------------------
+set(KSPACE_CXX_SOURCES
+  main.cpp
+  Containers/MatrixContainer.cpp
+  Containers/OutputStreamContainer.cpp
+  GetoptWin64/Getopt.cpp
+  Hdf5/Hdf5File.cpp
+  Hdf5/Hdf5FileHeader.cpp
+  KSpaceSolver/KSpaceFirstOrderSolver.cpp
+  Logger/Logger.cpp
+  MatrixClasses/BaseFloatMatrix.cpp
+  MatrixClasses/BaseIndexMatrix.cpp
+  MatrixClasses/ComplexMatrix.cpp
+  MatrixClasses/CufftComplexMatrix.cpp
+  MatrixClasses/IndexMatrix.cpp
+  MatrixClasses/RealMatrix.cpp
+  OutputStreams/BaseOutputStream.cpp
+  OutputStreams/CuboidOutputStream.cpp
+  OutputStreams/IndexOutputStream.cpp
+  OutputStreams/WholeDomainOutputStream.cpp
+  Parameters/CommandLineParameters.cpp
+  Parameters/CudaParameters.cpp
+  Parameters/Parameters.cpp
+)
+
+set(KSPACE_CUDA_SOURCES
+  Containers/CudaMatrixContainer.cu
+  KSpaceSolver/SolverCudaKernels.cu
+  MatrixClasses/TransposeCudaKernels.cu
+  OutputStreams/OutputStreamsCudaKernels.cu
+  Parameters/CudaDeviceConstants.cu
+)
+
+add_executable(kspaceFirstOrder-CUDA
+  ${KSPACE_CXX_SOURCES}
+  ${KSPACE_CUDA_SOURCES}
+)
+
+target_include_directories(kspaceFirstOrder-CUDA
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_property(TARGET kspaceFirstOrder-CUDA PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+set_property(TARGET kspaceFirstOrder-CUDA PROPERTY CUDA_ARCHITECTURES "${CMAKE_CUDA_ARCHITECTURES}")
+
+# -------------------------------------------------------------------------------------------------
+# Host and device compiler flags
+# -------------------------------------------------------------------------------------------------
+set(_cpu_arch_value "${KSPACE_CPU_ARCH}")
+string(TOLOWER "${_cpu_arch_value}" _cpu_arch_value)
+
+set(_cpu_arch_flags "")
+if(MSVC)
+  if(_cpu_arch_value STREQUAL "avx")
+    list(APPEND _cpu_arch_flags "/arch:AVX")
+  elseif(_cpu_arch_value STREQUAL "avx2")
+    list(APPEND _cpu_arch_flags "/arch:AVX2")
+  elseif(_cpu_arch_value STREQUAL "avx512")
+    message(FATAL_ERROR "KSPACE_CPU_ARCH=avx512 is not supported with MSVC toolchains.")
+  elseif(NOT _cpu_arch_value STREQUAL "native")
+    message(FATAL_ERROR "Unsupported value for KSPACE_CPU_ARCH: ${KSPACE_CPU_ARCH}")
+  endif()
+else()
+  if(_cpu_arch_value STREQUAL "native")
+    list(APPEND _cpu_arch_flags "-march=native" "-mtune=native")
+  elseif(_cpu_arch_value STREQUAL "avx")
+    list(APPEND _cpu_arch_flags "-m64" "-mavx")
+  elseif(_cpu_arch_value STREQUAL "avx2")
+    list(APPEND _cpu_arch_flags "-m64" "-mavx2")
+  elseif(_cpu_arch_value STREQUAL "avx512")
+    list(APPEND _cpu_arch_flags "-m64" "-mavx512f")
+  else()
+    message(FATAL_ERROR "Unsupported value for KSPACE_CPU_ARCH: ${KSPACE_CPU_ARCH}")
+  endif()
+endif()
+
+set(_host_opt_flags "")
+if(MSVC)
+  list(APPEND _host_opt_flags "/O2" "/MP")
+  if(KSPACE_ENABLE_FAST_MATH)
+    list(APPEND _host_opt_flags "/fp:fast")
+  endif()
+else()
+  list(APPEND _host_opt_flags "-O3")
+  if(KSPACE_ENABLE_FAST_MATH)
+    list(APPEND _host_opt_flags "-ffast-math" "-fassociative-math")
+  endif()
+endif()
+
+if(KSPACE_ENABLE_OPENMP AND OpenMP_CXX_FOUND)
+  set(_openmp_flags "${OpenMP_CXX_FLAGS}")
+  if(_openmp_flags)
+    separate_arguments(_openmp_flag_list NATIVE_COMMAND "${_openmp_flags}")
+    list(APPEND _host_opt_flags ${_openmp_flag_list})
+  endif()
+  target_link_libraries(kspaceFirstOrder-CUDA PRIVATE OpenMP::OpenMP_CXX)
+endif()
+
+target_compile_options(kspaceFirstOrder-CUDA
+  PRIVATE
+    $<$<COMPILE_LANGUAGE:CXX>:${_cpu_arch_flags}>
+    $<$<COMPILE_LANGUAGE:CXX>:${_host_opt_flags}>
+)
+
+set(_cuda_compile_flags "-O3" "--restrict" "--device-c")
+foreach(flag IN LISTS _cpu_arch_flags _host_opt_flags)
+  list(APPEND _cuda_compile_flags "-Xcompiler=${flag}")
+endforeach()
+
+target_compile_options(kspaceFirstOrder-CUDA
+  PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:${_cuda_compile_flags}>
+)
+
+# -------------------------------------------------------------------------------------------------
+# Defines and link libraries
+# -------------------------------------------------------------------------------------------------
+target_compile_definitions(kspaceFirstOrder-CUDA
+  PRIVATE
+    $<$<AND:$<BOOL:${WIN32}>,$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>>:WIN64>
+    _CONSOLE
+)
+
+target_link_libraries(kspaceFirstOrder-CUDA
+  PRIVATE
+    CUDA::cudart
+    CUDA::cufft
+    HDF5::HDF5
+    hdf5::hdf5_hl
+    ZLIB::ZLIB
+)
+
+if(SZIP_FOUND)
+  target_link_libraries(kspaceFirstOrder-CUDA PRIVATE SZIP::SZIP)
+endif()
+
+# TODO: Revisit Windows-specific runtime library selection (static vs dynamic CUDA).
+# TODO: Evaluate vcpkg integration to surface dependencies consistently across platforms.

--- a/cmake/SetupCUDA.cmake
+++ b/cmake/SetupCUDA.cmake
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# In this file, we:
+# 1. Set a default value for CMAKE_CUDA_ARCHITECTURES
+# 2. Use enable_language(CUDA) to retrieve CMAKE_CUDA_COMPILER_ID and CMAKE_CUDA_COMPILER_VERSION
+# 3. Parse and update CMAKE_CUDA_ARCHITECTURES to override `all` and `all-major` versions
+#    as well as create PTX for the last arch only
+
+message(STATUS "Configuring CUDA Architectures")
+
+# Default
+# Needed before enable_language(CUDA) or project(... LANGUAGE CUDA)
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    message(STATUS "CMAKE_CUDA_ARCHITECTURES not defined, setting it to `native`")
+    set(CMAKE_CUDA_ARCHITECTURES native)
+endif()
+
+# Enable CUDA language
+# Generates CMAKE_CUDA_COMPILER_ID and CMAKE_CUDA_COMPILER_VERSION needed below
+enable_language(CUDA)
+
+# Function to filter archs and create PTX for last arch
+function(update_cmake_cuda_architectures supported_archs warn)
+    list(APPEND CMAKE_MESSAGE_CONTEXT "update_cmake_cuda_architectures")
+
+    if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.8.0)
+            foreach(_blackwell_arch IN ITEMS "100" "120")
+                if("${_blackwell_arch}" IN_LIST supported_archs AND ${warn})
+                    message(WARNING "sm${_blackwell_arch} (Blackwell) not supported with nvcc < 12.8.0")
+                endif()
+                list(REMOVE_ITEM supported_archs "${_blackwell_arch}")
+            endforeach()
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.0.0)
+            if("90a" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm90a not supported with nvcc < 12.0.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "90a")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.8.0)
+            if("90" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm90 not supported with nvcc < 11.8.0")
+            endif()
+            if("89" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm89 not supported with nvcc < 11.8.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "90")
+            list(REMOVE_ITEM supported_archs "89")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.5.0)
+            if("87" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm87 not supported with nvcc < 11.5.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "87")
+        endif()
+        if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.2.0)
+            if("86" IN_LIST supported_archs AND ${warn})
+                message(WARNING "sm86 not supported with nvcc < 11.2.0")
+            endif()
+            list(REMOVE_ITEM supported_archs "86")
+        endif()
+    endif()
+
+    # Create SASS for all architectures in the list and
+    # create PTX for the latest architecture for forward-compatibility.
+    list(POP_BACK supported_archs latest_arch)
+    list(TRANSFORM supported_archs APPEND "-real")
+    list(APPEND supported_archs ${latest_arch})
+
+    set(CMAKE_CUDA_ARCHITECTURES ${supported_archs} PARENT_SCOPE)
+endfunction()
+
+# CMake "all" and "all-major" have too many CUDA archs, all the way back to sm_20
+#   https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/CUDA/architectures.cmake
+# Rapids does not list/support embedded devices (Xavier sm_72, Orin sm_87, Thor sm_90a)
+#   https://github.com/rapidsai/rapids-cmake/blob/branch-23.09/rapids-cmake/cuda/set_architectures.cmake#L60)
+# We need to have our own logic to select our own architectures and create PTX for the latest arch
+# for forward compatibility. Only keep the default cmake behavior for native archs input.
+# Start with "70", this is the lowest architecture supported by cuFFTDx
+if(CMAKE_CUDA_ARCHITECTURES STREQUAL "all")
+    set(CMAKE_CUDA_ARCHITECTURES "70;72;75;80;86;87;89;90;90a;100;120")
+    update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
+elseif(CMAKE_CUDA_ARCHITECTURES STREQUAL "all-major")
+    set(CMAKE_CUDA_ARCHITECTURES "70;80;90;100")
+    update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" FALSE)
+elseif(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
+    update_cmake_cuda_architectures("${CMAKE_CUDA_ARCHITECTURES}" TRUE)
+endif()
+
+message(STATUS "Using CUDA architectures: ${CMAKE_CUDA_ARCHITECTURES}")


### PR DESCRIPTION
Mirror of waltsims/kspaceFirstOrder-CUDA-linux#6 for the Windows-side CUDA repo. Same problem: \`kspacefirstorder-unified\`'s CMake CI workflow calls \`cmake -S repos/kspaceFirstOrder-cuda-windows\` but the cuda-windows submodule pinned on main (\`e8661b1\`, post-#2) lacks \`CMakeLists.txt\`.

## What changes

- **\`CMakeLists.txt\`** (new) — adapted from a previous cmake-build effort at SHA \`e0643db\`. Default \`CMAKE_CUDA_ARCHITECTURES\` set to \`75;80;86;87;89;90;90a;100;120\` (adds sm_86 + Blackwell vs the source snapshot's \`75;80;87;89;90;90a\`).
- **\`cmake/SetupCUDA.cmake\`** (new) — version-aware arch filtering with a new Blackwell guard: drops sm_100 / sm_120 when \`nvcc < 12.8.0\`, with a warning when the user explicitly requested them.

The legacy \`kspaceFirstOrder-CUDA.vcxproj\` is unchanged and still on main — the two build paths coexist. Unified CI's \`windows-cuda\` job uses CMake; users who want MSBuild can still use the .vcxproj.

## Test plan

- [ ] Local \`cmake -S . -B build\` configures cleanly on a CUDA 13.0 Windows host
- [ ] \`cmake --build build --config Release\` produces \`kspaceFirstOrder-CUDA.exe\` with the Blackwell arches included
- [ ] On a CUDA 12.2 host, configure logs warn about sm_100/sm_120 and produces a binary with sm_75..sm_90a only
- [ ] unified CI passes after submodule SHA bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `CMakeLists.txt` and a `cmake/SetupCUDA.cmake` to the Windows CUDA submodule so that the unified CI workflow can configure the project with CMake. The `SetupCUDA.cmake` extends an upstream NVIDIA template with a Blackwell guard that drops sm_100/sm_120 when nvcc is older than 12.8.

- **`CMakeLists.txt`**: New CMake entry point covering source lists, compiler flags (MSVC/GCC paths), HDF5/ZLIB/SZIP/CUDAToolkit dependencies, and target-level arch configuration; has a mixed HDF5 target-namespace bug (`hdf5::hdf5_hl` alongside `HDF5::HDF5`) that can cause a build failure on module-based HDF5 installs, and a redundant `--device-c` flag that duplicates CMake's `CUDA_SEPARABLE_COMPILATION` property.
- **`cmake/SetupCUDA.cmake`**: Version-aware arch filter that transforms the architecture list so only the latest arch gets PTX (for forward compatibility) and older ones get SASS only; the Blackwell guard and version ladder look correct.

<h3>Confidence Score: 3/5</h3>

The CMake build file has a HDF5 target-namespace mismatch that will cause a configuration failure on Windows systems where HDF5 is found through CMake's FindHDF5 module rather than an HDF5-provided config package.

The HDF5 link target inconsistency (`HDF5::HDF5` from the Find module on one line, `hdf5::hdf5_hl` from the HDF5 config package on the next) is a real build breakage waiting on whichever installation path CMake resolves first. The redundant `--device-c` flag is unlikely to break a build but contradicts the `CUDA_SEPARABLE_COMPILATION` property CMake already manages. Both issues are in the newly introduced `CMakeLists.txt`; `SetupCUDA.cmake` is solid.

CMakeLists.txt — specifically the `target_link_libraries` block and the CUDA compile flags section.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CMakeLists.txt | New CMake build file for Windows CUDA target; has a mixed HDF5 target namespace issue (`hdf5::hdf5_hl` vs `HDF5::HDF5_HL`) that can break builds, a redundant `--device-c` flag alongside `CUDA_SEPARABLE_COMPILATION ON`, and a misleading arch-separator description in the cache variable. |
| cmake/SetupCUDA.cmake | New Blackwell-aware CUDA architecture filter; version guards and PTX-for-latest-arch logic look correct. One edge case: if filtering removes all architectures, `list(POP_BACK)` silently sets an empty list, but the default arch set makes this unreachable in practice. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[cmake -S . -B build] --> B{CMAKE_CUDA_ARCHITECTURES\ndefined on CLI?}
    B -- yes --> C[Use CLI value]
    B -- no --> D{KSPACE_CUDA_ARCH_LIST\nset?}
    D -- yes --> E[Use KSPACE_CUDA_ARCH_LIST]
    D -- no --> F[Default: 75;80;86;87;89;90;90a;100;120]
    C --> G[include SetupCUDA.cmake]
    E --> G
    F --> G
    G --> H{CMAKE_CUDA_ARCHITECTURES == 'all'?}
    H -- yes --> I[Expand to 70..120 list]
    H -- no --> J{== 'all-major'?}
    J -- yes --> K[Expand to 70;80;90;100]
    J -- no --> L{== 'native'?}
    L -- yes --> M[Pass through unchanged]
    L -- no --> N[update_cmake_cuda_architectures warn=TRUE]
    I --> O[update_cmake_cuda_architectures warn=FALSE]
    K --> O
    N --> P{nvcc < 12.8?}
    O --> P
    P -- yes --> Q[Drop sm_100 sm_120 with warning if requested]
    P -- no --> R[Keep Blackwell arches]
    Q --> S{nvcc < 12.0?}
    R --> S
    S -- yes --> T[Drop sm_90a]
    S -- no --> U[Keep sm_90a]
    T --> V[Further version checks < 11.8 / 11.5 / 11.2]
    U --> V
    V --> W[POP_BACK latest arch, append -real to rest, keep latest as PTX]
    W --> X[Set CMAKE_CUDA_ARCHITECTURES in PARENT_SCOPE]
    X --> Y[set_property TARGET CUDA_ARCHITECTURES]
    Y --> Z[nvcc compiles SASS for all, PTX for latest arch]
```

<sub>Reviews (1): Last reviewed commit: ["Add CMakeLists.txt + Blackwell-aware Set..."](https://github.com/waltsims/kspacefirstorder-cuda-windows/commit/6b394b5c7c8acb2d9928fe1a12ce350a5655ab0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32460288)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->