### PR TITLE
Pre-filter Blackwell archs before enable_language(CUDA)

### DIFF
--- a/cmake/SetupCUDA.cmake
+++ b/cmake/SetupCUDA.cmake
@@ -28,6 +28,44 @@ if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
     set(CMAKE_CUDA_ARCHITECTURES native)
 endif()
 
+# Pre-enable_language pre-filter: probe nvcc version BEFORE
+# enable_language(CUDA) so we can drop architectures the installed
+# toolchain doesn't support. Otherwise the test compile done inside
+# enable_language() fails with "Unsupported gpu architecture" before
+# CMAKE_CUDA_COMPILER_VERSION is set and our post-enable filter (in
+# update_cmake_cuda_architectures below) gets a chance to run.
+#
+# Currently this only needs to handle the Blackwell archs (100, 120)
+# which require nvcc >= 12.8; older arches in our default list
+# (75..90a) work on every nvcc the project supports.
+if(NOT CMAKE_CUDA_ARCHITECTURES STREQUAL "native")
+    if(NOT DEFINED CMAKE_CUDA_COMPILER)
+        find_program(_probe_nvcc nvcc
+            PATHS ENV CUDAToolkit_ROOT ENV CUDA_HOME ENV CUDA_PATH
+            PATH_SUFFIXES bin)
+    else()
+        set(_probe_nvcc "${CMAKE_CUDA_COMPILER}")
+    endif()
+    if(_probe_nvcc)
+        execute_process(
+            COMMAND "${_probe_nvcc}" --version
+            OUTPUT_VARIABLE _probe_nvcc_version_output
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET)
+        if(_probe_nvcc_version_output MATCHES "release ([0-9]+)\\.([0-9]+)")
+            math(EXPR _probe_cuda_num "${CMAKE_MATCH_1} * 100 + ${CMAKE_MATCH_2}")
+            if(_probe_cuda_num LESS 1208)
+                foreach(_blackwell_arch IN ITEMS "100" "120")
+                    if("${_blackwell_arch}" IN_LIST CMAKE_CUDA_ARCHITECTURES)
+                        message(STATUS "Pre-filter: dropping sm_${_blackwell_arch} (Blackwell) — nvcc ${CMAKE_MATCH_1}.${CMAKE_MATCH_2} predates 12.8")
+                        list(REMOVE_ITEM CMAKE_CUDA_ARCHITECTURES "${_blackwell_arch}")
+                    endif()
+                endforeach()
+            endif()
+        endif()
+    endif()
+endif()
+
 # Enable CUDA language
 # Generates CMAKE_CUDA_COMPILER_ID and CMAKE_CUDA_COMPILER_VERSION needed below
 enable_language(CUDA)


### PR DESCRIPTION
Mirror of waltsims/kspaceFirstOrder-CUDA-linux fix/prefilter-cuda-archs-pre-enable. Same fix: probe nvcc version before enable_language(CUDA) so older toolchains can drop sm_100/sm_120 before the configure-time test compile sees an unsupported architecture.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ports the Blackwell architecture pre-filter fix from the Linux sister repo to the Windows variant of `kspaceFirstOrder-CUDA`. The fix probes the nvcc version before `enable_language(CUDA)` and removes sm_100/sm_120 from `CMAKE_CUDA_ARCHITECTURES` when nvcc < 12.8, preventing a configure-time test-compile failure with older toolchains.

- The pre-filter logic itself (version regex, math comparison, list removal) is correct and mirrors the Linux fix accurately.
- The filter is placed in `SetupCUDA.cmake`, but in this Windows repo `CMakeLists.txt` enables CUDA via `project(… LANGUAGES CXX CUDA)` *before* including `SetupCUDA.cmake`, so the test compile has already run by the time the pre-filter executes — the `enable_language(CUDA)` on line 71 is a no-op.
- `find_program(_probe_nvcc …)` writes a visible `FILEPATH` entry into the CMake cache that can become stale if the CUDA toolkit path changes.

<h3>Confidence Score: 3/5</h3>

The change adds no harmful behaviour, but the configure-time failure it targets is not prevented in this Windows repo.

The pre-filter logic is correct in isolation, but it runs after the project() call in CMakeLists.txt has already triggered the CUDA language test compile. The configure failure still occurs before SetupCUDA.cmake is ever included.

cmake/SetupCUDA.cmake and CMakeLists.txt — the pre-filter is in the wrong file for this Windows repo structure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| cmake/SetupCUDA.cmake | Adds a pre-`enable_language(CUDA)` Blackwell architecture filter, but in this Windows repo the `enable_language(CUDA)` test compile fires earlier via `project(… LANGUAGES CXX CUDA)` in CMakeLists.txt, making the pre-filter a no-op for the scenario it is intended to fix. Also introduces a `find_program` cache-variable leak. |

</details>

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CML as CMakeLists.txt
    participant CMake as CMake Runtime
    participant SC as SetupCUDA.cmake
    participant nvcc as nvcc

    CML->>CMake: "project(LANGUAGES CXX CUDA) line 10"
    Note over CMake: "enable_language(CUDA) fires here — test compile uses cached CMAKE_CUDA_ARCHITECTURES including sm_100/sm_120"
    CMake->>nvcc: "test compile with full arch list"
    nvcc-->>CMake: "Unsupported gpu architecture if nvcc lt 12.8"

    CML->>CML: "set CMAKE_CUDA_ARCHITECTURES 75..100..120 line 34"
    CML->>SC: "include SetupCUDA.cmake line 37"

    SC->>nvcc: "_probe_nvcc --version (new pre-filter)"
    nvcc-->>SC: "version string"
    SC->>SC: "strip sm_100 and sm_120 if nvcc lt 12.8"

    SC->>CMake: "enable_language(CUDA) line 71"
    Note over CMake: "NO-OP: CUDA already enabled by project() — pre-filter too late"
    SC->>SC: "update_cmake_cuda_architectures() post-filter runs"
```

<sub>Reviews (1): Last reviewed commit: ["Pre-filter Blackwell archs before enable..."](https://github.com/waltsims/kspacefirstorder-cuda-windows/commit/a7e323efec861264e801c9b4d8ccc8284508a8c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32460646)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->